### PR TITLE
Option to write one-off CLI commands

### DIFF
--- a/lib/ConsoleKit/Console.php
+++ b/lib/ConsoleKit/Console.php
@@ -53,6 +53,9 @@ class Console implements TextWriter
     /** @var bool */
     protected $verboseException = false;
 
+    /** @var bool */
+    protected $singleCommand = false;
+
     /**
      * @param array $commands
      */
@@ -279,6 +282,17 @@ class Console implements TextWriter
     {
         return $this->defaultCommand;
     }
+
+    /**
+     * Turn off command parsing
+     *
+     * @param type $singleCommand
+     * @return Console
+     */
+    public function setSingleCommand($singleCommand) {
+        $this->singleCommand = $singleCommand;
+        return $this;
+    }
     
     /**
      * @param array $args
@@ -292,6 +306,10 @@ class Console implements TextWriter
             }
 
             list($args, $options) = $this->getOptionsParser()->parse($argv);
+            if($this->defaultCommand && $this->singleCommand) {
+                return $this->execute($this->defaultCommand, $args, $options);
+            }
+            
             if (!count($args)) {
                 if ($this->defaultCommand) {
                     $args[] = $this->defaultCommand;

--- a/tests/ConsoleKit/Tests/ConsoleTest.php
+++ b/tests/ConsoleKit/Tests/ConsoleTest.php
@@ -113,4 +113,11 @@ class ConsoleTest extends ConsoleKitTestCase
         $this->console->addCommand('ConsoleKit\Tests\TestCommand', null, true);
         $this->console->run(array());
     }
+
+    public function testOneCommandWithArguments() {
+        $this->expectOutputString("hello foobar!\n");
+        $this->console->addCommand('ConsoleKit\Tests\TestCommand', null, true);
+        $this->console->setSingleCommand(true);
+        $this->console->run(array('foobar'));
+    }
 }


### PR DESCRIPTION
This addition is useful to write singe-purpose CLI scripts instead of console-style CLI scripts.

Normally the Console expects either a command name and arguments or executes the the default command without arguments. With this addition, when `setSingleCommand(true)` is called, only the default
command is executed. 
