### PR TITLE
Fixed progress bar showin time left

### DIFF
--- a/src/ConsoleKit/Widgets/ProgressBar.php
+++ b/src/ConsoleKit/Widgets/ProgressBar.php
@@ -163,7 +163,7 @@ class ProgressBar extends AbstractWidget
         if ($this->showRemainingTime) {
             $speed = (time() - $this->startTime) / $this->value;
             $remaining = number_format(round($speed * ($this->total - $this->value), 2), 2);
-            $output .= "$remaining sec remaining";
+            $output .= " - $remaining sec remaining";
         }
 
         return $output;


### PR DESCRIPTION
It used to show the time left with no space from the progress counting 
